### PR TITLE
Add xhost

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -30,6 +30,7 @@ let
       pythonPackages.docker_compose
       travis
       xvfb_run
+      xorg.xhost
     ];
   };
 in


### PR DESCRIPTION
Running 'xhost +' on the host allows docker containers to connect to host's X
server. This is used to run e2e tests in gnss-site-manager.