### PR TITLE
Clone master branch of each project

### DIFF
--- a/clone.sh
+++ b/clone.sh
@@ -13,5 +13,5 @@ esac
 (cd .. && \
 for m in "${MODULES[@]}"
 do
-    git clone "${repo_url_prefix}/${m}"
+    git clone -b master "${repo_url_prefix}/${m}"
 done)


### PR DESCRIPTION
Repositories may override their default branch, but master branches
are as a rule most likely to be stable.